### PR TITLE
Fix: npm package name for `hardhat-gasless-deployer` in plugins.ts

### DIFF
--- a/docs/src/content/hardhat-runner/plugins/plugins.ts
+++ b/docs/src/content/hardhat-runner/plugins/plugins.ts
@@ -811,7 +811,7 @@ const communityPlugins: IPlugin[] = [
     name: "hardhat-gasless-deployer",
     author: "Ahmed Ali",
     authorUrl: "https://twitter.com/0xAhmedAli",
-    npmPackage: "https://www.npmjs.com/package/hardhat-gasless-deployer",
+    npmPackage: "hardhat-gasless-deployer",
     description: "Deploy contracts with Hardhat using Gas Station Network",
     tags: ["GSN", "Gasless", "Deployment"],
   },


### PR DESCRIPTION
Fixing broken the npm package link.